### PR TITLE
Fix some TSI errors

### DIFF
--- a/net/tsi/af_tsi.c
+++ b/net/tsi/af_tsi.c
@@ -33,7 +33,7 @@ static int tsi_create_control_socket(struct socket **csocket)
 			    SOCK_DGRAM, 0, csocket, 1);
 	if (err) {
 		pr_debug("%s: error creating control socket\n", __func__);
-		goto release;
+		return err;
 	}
 
 	memset(&vm_addr, 0, sizeof(struct sockaddr_vm));

--- a/security/selinux/hooks.c
+++ b/security/selinux/hooks.c
@@ -1259,7 +1259,10 @@ static inline u16 socket_type_to_security_class(int family, int type, int protoc
 			return SECCLASS_XDP_SOCKET;
 		case PF_MCTP:
 			return SECCLASS_MCTP_SOCKET;
-#if PF_MAX > 46
+		case PF_TSI:
+			return SECCLASS_TSI_SOCKET;
+
+#if PF_MAX > 47
 #error New address family defined, please update this function.
 #endif
 		}

--- a/security/selinux/include/classmap.h
+++ b/security/selinux/include/classmap.h
@@ -237,6 +237,8 @@ const struct security_class_mapping secclass_map[] = {
 	  { COMMON_SOCK_PERMS, NULL } },
 	{ "smc_socket",
 	  { COMMON_SOCK_PERMS, NULL } },
+	{ "tsi_socket",
+	  { COMMON_SOCK_PERMS, NULL } },
 	{ "infiniband_pkey",
 	  { "access", NULL } },
 	{ "infiniband_endport",
@@ -257,6 +259,6 @@ const struct security_class_mapping secclass_map[] = {
 	{ NULL }
   };
 
-#if PF_MAX > 46
+#if PF_MAX > 47
 #error New address family defined, please update secclass_map.
 #endif


### PR DESCRIPTION
1) Fix selinux build-time errors as discussed at https://github.com/containers/libkrunfw/pull/36.

2) Fix `tsi_create_control_socket` error handling so it doesn't try to release `csocket` if it fails to create it. Not sure if this one really matters